### PR TITLE
replace deprecated categorical! with transfrom! 

### DIFF
--- a/src/FestaetalLib/src/data_analysis_crcns_pvc8.jl
+++ b/src/FestaetalLib/src/data_analysis_crcns_pvc8.jl
@@ -63,7 +63,8 @@ function SpikingData_pvc8()
     return dfout
   end
   datadf = vcat(datadfs...)
-  categorical!(datadf,:session;compress=true)
+  transform!(datadf, :session => categorical => :session)
+  # categorical!(datadf,:session;compress=true)
   datadf[!,:electrode] .= UInt8(1)
   # category is missing or 1 , not 2. Remove unnecessary views
   filter!(:category => (c -> ismissing(c) || c != 2 ),  views)

--- a/src/Pyramids/examples/frame_interpolation.jl
+++ b/src/Pyramids/examples/frame_interpolation.jl
@@ -9,7 +9,7 @@ using ColorTypes
 using Pyramids
 using Interpolations
 
-type PhasePyramid <: PyramidType
+struct PhasePyramid <: PyramidType
 end
 
 function shift_correction(phi_delta::ImagePyramid; shift_limit=0.5)


### PR DESCRIPTION
`categorical!` was deprecated in favor of `transform!` in [DataFrames.jl 0.22](https://github.com/JuliaData/DataFrames.jl/releases/tag/v0.22.0l), so anyone using current DataFrames.jl (v1.5.0) will error when trying to recreate panel 2C.